### PR TITLE
Install dependencies with setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ scikit-image>=0.15.0
 scikit-learn>=0.21.2
 vispy>=0.6.1
 torch>=1.2.0
-torchvision>=1.2.0
-
+torchvision>=0.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,17 @@
 # !/usr/bin/env python
 
 from distutils.core import setup
+
+
+def parse_requirements_file(filename):
+    with open(filename) as fid:
+        requires = [l.strip() for l in fid.readlines() if l]
+
+    return requires
+
+INSTALL_REQUIRES = parse_requirements_file('requirements.txt')
+print(INSTALL_REQUIRES)
+
 setup(
     name='segmentify',
     packages=[],
@@ -31,4 +42,5 @@ setup(
         'Operating System :: Unix',
         'Operating System :: MacOS',
     ],
+    install_requires=INSTALL_REQUIRES,
 )


### PR DESCRIPTION
This pull request closes https://github.com/transformify-plugins/segmentify/issues/19

The PR does two things:
1. Adds install dependencies to the `setup.py` file, based on the contents of `requirements.txt`. I've used [the same approach as scikit-image](https://github.com/scikit-image/scikit-image/blob/634ef74811520159c70a896f42242d3c9a5b95fc/setup.py#L117) for this.

2. Change the torchvision minimum version number to 0.4.0. 
I did this because the `requirements.txt` file currently contains the line `torchvision>=1.2.0`, but this can't be correct since the Understandably this causes an error if you're trying to `pip install -r requirements.txt`.
I don't know which torchvision version was originally intended, my best guess is we want `torchvision>=0.4.0` (since that was the version released on the same day as torch version 1.2.0, which is what we have specified for torch in the requirements file).



